### PR TITLE
Fix Cancel button text legibility in SystemPromptEditor

### DIFF
--- a/AiStudio4/AiStudioClient/src/components/SystemPrompt/SystemPromptEditor.tsx
+++ b/AiStudio4/AiStudioClient/src/components/SystemPrompt/SystemPromptEditor.tsx
@@ -612,9 +612,12 @@ export function SystemPromptEditor({ initialPrompt, onClose, onApply }: SystemPr
               <Button
                 type="button"
                 onClick={onClose}
-                variant="outline"
                 disabled={isProcessing}
-                className="btn-secondary"
+                style={{
+                  backgroundColor: 'var(--global-background-color)',
+                  borderColor: 'var(--global-border-color)',
+                  color: 'var(--global-text-color)'
+                }}
               >
                 Cancel
               </Button>


### PR DESCRIPTION
## Description

Fixes issue #17 where the Cancel button text in the SystemPromptEditor modal was barely legible due to pale grey text on a white background.

## Root Cause

The Cancel button had conflicting styling between:
- `variant="outline"` from the Button component
- `className="btn-secondary"` from custom CSS classes

This caused the button to use unmapped CSS variables that resulted in poor text contrast.

## Solution

- Removed conflicting `variant="outline"` and `className="btn-secondary"` props
- Applied global theme variables using inline styles as per ComponentTheming.md guidelines:
  - `backgroundColor: 'var(--global-background-color)'`
  - `borderColor: 'var(--global-border-color)'` 
  - `color: 'var(--global-text-color)'`

## Testing

To test the fix:
1. Create a system prompt
2. Scroll to the end of the modal dialog
3. Verify the 'Cancel' button text is now clearly legible (dark text on button background)

## Files Changed

- `src/components/SystemPrompt/SystemPromptEditor.tsx` - Fixed Cancel button styling

Resolves #17