### PR TITLE
Add documentation for GitHubUpdatePullRequestTool and GitHubListPullRequestsTool

### DIFF
--- a/AiStudio4/Core/Tools/GitHub/GitHubCreatePullRequestTool.cs
+++ b/AiStudio4/Core/Tools/GitHub/GitHubCreatePullRequestTool.cs
@@ -132,8 +132,10 @@ namespace AiStudio4.Core.Tools.GitHub
                 bool draft = parameters.TryGetValue("draft", out var draftObj) && bool.TryParse(draftObj?.ToString(), out bool draftValue) && draftValue;
                 bool maintainerCanModify = !parameters.TryGetValue("maintainer_can_modify", out var maintainerObj) || !bool.TryParse(maintainerObj?.ToString(), out bool maintainerValue) || maintainerValue;
 
+                string apiKey = _generalSettingsService.GetDecryptedGitHubApiKey();
+
                 // Get GitHub token from extra properties
-                if (!extraProperties.TryGetValue("GitHubToken", out string token) || string.IsNullOrWhiteSpace(token))
+                if (string.IsNullOrWhiteSpace(apiKey))
                 {
                     return CreateResult(false, false, "Error: GitHub Personal Access Token not configured. Please set 'GitHubToken' in the tool's extra properties.");
                 }
@@ -155,7 +157,7 @@ namespace AiStudio4.Core.Tools.GitHub
                 var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
 
                 // Set authorization header
-                _httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+                _httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", apiKey);
 
                 // Make the API request
                 string url = $"https://api.github.com/repos/{owner}/{repo}/pulls";

--- a/AiStudio4/Core/Tools/GitHub/GitHubListPullRequestsTool.cs
+++ b/AiStudio4/Core/Tools/GitHub/GitHubListPullRequestsTool.cs
@@ -1,0 +1,172 @@
+﻿// AiStudio4.Core\Tools\GitHub\GitHubListPullRequestsTool.cs
+using AiStudio4.Core.Interfaces;
+using AiStudio4.Core.Models;
+using AiStudio4.InjectedDependencies;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace AiStudio4.Core.Tools.GitHub
+{
+    /// <summary>
+    /// Implementation of the GitHub List Pull Requests API tool
+    /// </summary>
+    public class GitHubListPullRequestsTool : BaseToolImplementation
+    {
+        private readonly HttpClient _httpClient;
+
+        public GitHubListPullRequestsTool(ILogger<GitHubListPullRequestsTool> logger, IGeneralSettingsService generalSettingsService, IStatusMessageService statusMessageService)
+            : base(logger, generalSettingsService, statusMessageService)
+        {
+            _httpClient = new HttpClient();
+            _httpClient.DefaultRequestHeaders.Add("User-Agent", "AiStudio4-GitHub-Tool");
+        }
+
+        /// <summary>
+        /// Gets the GitHub List Pull Requests tool definition
+        /// </summary>
+        public override Tool GetToolDefinition()
+        {
+            return new Tool
+            {
+                Guid = "c8d9e0f1-a2b3-5678-9012-cdef34567890",
+                Name = "GitHubListPullRequests",
+                Description = "Lists pull requests for a GitHub repository. Requires GitHub Personal Access Token with repo permissions.",
+                Schema = @"{
+  ""name"": ""GitHubListPullRequests"",
+  ""description"": ""Lists pull requests for a GitHub repository. Requires GitHub Personal Access Token with repo permissions."",
+  ""input_schema"": {
+    ""type"": ""object"",
+    ""properties"": {
+      ""owner"": { ""type"": ""string"", ""description"": ""Repository owner (username or organization)."" },
+      ""repo"": { ""type"": ""string"", ""description"": ""Repository name."" },
+      ""state"": { ""type"": ""string"", ""description"": ""State of the PR: open, closed, or all. (Optional)"" },
+      ""head"": { ""type"": ""string"", ""description"": ""Filter by head user or branch name. (Optional)"" },
+      ""base"": { ""type"": ""string"", ""description"": ""Filter by base branch name. (Optional)"" },
+      ""per_page"": { ""type"": ""integer"", ""description"": ""Number of results per page (max 100). (Optional)"" },
+      ""page"": { ""type"": ""integer"", ""description"": ""Page number of the results to fetch. (Optional)"" }
+    },
+    ""required"": [""owner"", ""repo""]
+  }
+}",
+                Categories = new List<string> {"APITools", "GitHub" },
+                OutputFileType = "json",
+                Filetype = string.Empty,
+                LastModified = DateTime.UtcNow
+            };
+        }
+
+        public override async Task<BuiltinToolResult> ProcessAsync(string toolParameters, Dictionary<string, string> extraProperties)
+        {
+            SendStatusUpdate("Starting GitHub List Pull Requests tool execution...");
+            try
+            {
+                var parameters = JsonConvert.DeserializeObject<Dictionary<string, object>>(toolParameters) ?? new Dictionary<string, object>();
+                if (!parameters.TryGetValue("owner", out var ownerObj) || string.IsNullOrWhiteSpace(ownerObj?.ToString()))
+                {
+                    return CreateResult(false, false, "Error: 'owner' parameter is required and cannot be empty.");
+                }
+                string owner = ownerObj.ToString();
+                if (!parameters.TryGetValue("repo", out var repoObj) || string.IsNullOrWhiteSpace(repoObj?.ToString()))
+                {
+                    return CreateResult(false, false, "Error: 'repo' parameter is required and cannot be empty.");
+                }
+                string repo = repoObj.ToString();
+                string state = parameters.TryGetValue("state", out var stateObj) ? stateObj?.ToString() : null;
+                string head = parameters.TryGetValue("head", out var headObj) ? headObj?.ToString() : null;
+                string baseBranch = parameters.TryGetValue("base", out var baseObj) ? baseObj?.ToString() : null;
+                int? perPage = parameters.TryGetValue("per_page", out var perPageObj) && int.TryParse(perPageObj?.ToString(), out int pp) ? pp : (int?)null;
+                int? page = parameters.TryGetValue("page", out var pageObj) && int.TryParse(pageObj?.ToString(), out int pg) ? pg : (int?)null;
+                string apiKey = _generalSettingsService.GetDecryptedGitHubApiKey();
+                if (string.IsNullOrWhiteSpace(apiKey))
+                {
+                    return CreateResult(false, false, "Error: GitHub Personal Access Token not configured. Please set 'GitHubToken' in the tool's extra properties.");
+                }
+                SendStatusUpdate($"Listing pull requests for {owner}/{repo}...");
+                var queryParams = new List<string>();
+                if (!string.IsNullOrWhiteSpace(state)) queryParams.Add($"state={Uri.EscapeDataString(state)}");
+                if (!string.IsNullOrWhiteSpace(head)) queryParams.Add($"head={Uri.EscapeDataString(head)}");
+                if (!string.IsNullOrWhiteSpace(baseBranch)) queryParams.Add($"base={Uri.EscapeDataString(baseBranch)}");
+                if (perPage.HasValue) queryParams.Add($"per_page={perPage.Value}");
+                if (page.HasValue) queryParams.Add($"page={page.Value}");
+                string query = queryParams.Count > 0 ? "?" + string.Join("&", queryParams) : string.Empty;
+                _httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", apiKey);
+                string url = $"https://api.github.com/repos/{owner}/{repo}/pulls{query}";
+                var response = await _httpClient.GetAsync(url);
+                string responseContent = await response.Content.ReadAsStringAsync();
+                if (response.IsSuccessStatusCode)
+                {
+                    var prArray = JsonConvert.DeserializeObject<JArray>(responseContent);
+                    var prList = new List<object>();
+                    foreach (var pr in prArray)
+                    {
+                        prList.Add(new
+                        {
+                            number = pr["number"]?.ToObject<int>(),
+                            title = pr["title"]?.ToString(),
+                            state = pr["state"]?.ToString(),
+                            head = pr["head"]?["ref"]?.ToString(),
+                            base_branch = pr["base"]?["ref"]?.ToString(),
+                            url = pr["html_url"]?.ToString(),
+                            user = pr["user"]?["login"]?.ToString(),
+                            created_at = pr["created_at"]?.ToString(),
+                            updated_at = pr["updated_at"]?.ToString()
+                        });
+                    }
+                    var result = new
+                    {
+                        success = true,
+                        count = prList.Count,
+                        pullRequests = prList
+                    };
+                    return CreateResult(true, false, JsonConvert.SerializeObject(result, Formatting.Indented));
+                }
+                else
+                {
+                    _logger.LogError("GitHub API error: {StatusCode} - {Content}", response.StatusCode, responseContent);
+                    string errorMessage = "Failed to list pull requests.";
+                    try
+                    {
+                        var errorResponse = JsonConvert.DeserializeObject<JObject>(responseContent);
+                        if (errorResponse["message"] != null)
+                        {
+                            errorMessage = $"GitHub API Error: {errorResponse["message"]}";
+                            if (errorResponse["errors"] != null)
+                            {
+                                var errors = errorResponse["errors"] as JArray;
+                                if (errors?.Count > 0)
+                                {
+                                    errorMessage += $"\nDetails: {string.Join(", ", errors.Select(e => e["message"]?.ToString()))}";
+                                }
+                            }
+                        }
+                    }
+                    catch
+                    {
+                        errorMessage = $"GitHub API Error: {response.StatusCode} - {responseContent}";
+                    }
+                    return CreateResult(false, false, errorMessage);
+                }
+            }
+            catch (HttpRequestException httpEx)
+            {
+                _logger.LogError(httpEx, "HTTP error in GitHub List Pull Requests tool");
+                return CreateResult(false, false, $"Network error: {httpEx.Message}");
+            }
+            catch (JsonException jsonEx)
+            {
+                _logger.LogError(jsonEx, "JSON parsing error in GitHub List Pull Requests tool");
+                return CreateResult(false, false, $"Error parsing parameters: {jsonEx.Message}");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unexpected error in GitHub List Pull Requests tool");
+                return CreateResult(false, false, $"Unexpected error: {ex.Message}");
+            }
+        }
+    }
+}

--- a/AiStudio4/Core/Tools/GitHub/GitHubUpdatePullRequestTool.cs
+++ b/AiStudio4/Core/Tools/GitHub/GitHubUpdatePullRequestTool.cs
@@ -1,0 +1,174 @@
+﻿// AiStudio4.Core\Tools\GitHub\GitHubUpdatePullRequestTool.cs
+using AiStudio4.Core.Interfaces;
+using AiStudio4.Core.Models;
+using AiStudio4.InjectedDependencies;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AiStudio4.Core.Tools.GitHub
+{
+    /// <summary>
+    /// Implementation of the GitHub Update Pull Request API tool
+    /// </summary>
+    public class GitHubUpdatePullRequestTool : BaseToolImplementation
+    {
+        private readonly HttpClient _httpClient;
+
+        public GitHubUpdatePullRequestTool(ILogger<GitHubUpdatePullRequestTool> logger, IGeneralSettingsService generalSettingsService, IStatusMessageService statusMessageService)
+            : base(logger, generalSettingsService, statusMessageService)
+        {
+            _httpClient = new HttpClient();
+            _httpClient.DefaultRequestHeaders.Add("User-Agent", "AiStudio4-GitHub-Tool");
+        }
+
+        /// <summary>
+        /// Gets the GitHub Update Pull Request tool definition
+        /// </summary>
+        public override Tool GetToolDefinition()
+        {
+            return new Tool
+            {
+                Guid = "b7c8d9e0-f2a1-4567-8901-bcdef2345678",
+                Name = "GitHubUpdatePullRequest",
+                Description = "Updates an existing pull request in a GitHub repository. Requires GitHub Personal Access Token with repo permissions.",
+                Schema = @"{
+  ""name"": ""GitHubUpdatePullRequest"",
+  ""description"": ""Updates an existing pull request in a GitHub repository. Requires GitHub Personal Access Token with repo permissions."",
+  ""input_schema"": {
+    ""type"": ""object"",
+    ""properties"": {
+      ""owner"": { ""type"": ""string"", ""description"": ""Repository owner (username or organization)."" },
+      ""repo"": { ""type"": ""string"", ""description"": ""Repository name."" },
+      ""pull_number"": { ""type"": ""integer"", ""description"": ""The number of the pull request to update."" },
+      ""title"": { ""type"": ""string"", ""description"": ""The new title for the pull request. (Optional)"" },
+      ""body"": { ""type"": ""string"", ""description"": ""The new contents of the pull request (Markdown). (Optional)"" },
+      ""state"": { ""type"": ""string"", ""description"": ""State of the PR: open or closed. (Optional)"" },
+      ""base"": { ""type"": ""string"", ""description"": ""The branch you want the changes pulled into. (Optional)"" },
+      ""maintainer_can_modify"": { ""type"": ""boolean"", ""description"": ""Whether maintainers can modify the PR. (Optional)"" }
+    },
+    ""required"": [""owner"", ""repo"", ""pull_number""]
+  }
+}",
+                Categories = new List<string> {"APITools", "GitHub" },
+                OutputFileType = "json",
+                Filetype = string.Empty,
+                LastModified = DateTime.UtcNow
+            };
+        }
+
+        public override async Task<BuiltinToolResult> ProcessAsync(string toolParameters, Dictionary<string, string> extraProperties)
+        {
+            SendStatusUpdate("Starting GitHub Update Pull Request tool execution...");
+            try
+            {
+                var parameters = JsonConvert.DeserializeObject<Dictionary<string, object>>(toolParameters) ?? new Dictionary<string, object>();
+                if (!parameters.TryGetValue("owner", out var ownerObj) || string.IsNullOrWhiteSpace(ownerObj?.ToString()))
+                {
+                    return CreateResult(false, false, "Error: 'owner' parameter is required and cannot be empty.");
+                }
+                string owner = ownerObj.ToString();
+                if (!parameters.TryGetValue("repo", out var repoObj) || string.IsNullOrWhiteSpace(repoObj?.ToString()))
+                {
+                    return CreateResult(false, false, "Error: 'repo' parameter is required and cannot be empty.");
+                }
+                string repo = repoObj.ToString();
+                if (!parameters.TryGetValue("pull_number", out var pullNumberObj) || !int.TryParse(pullNumberObj.ToString(), out int pullNumber))
+                {
+                    return CreateResult(false, false, "Error: 'pull_number' parameter is required and must be an integer.");
+                }
+                // Optional fields
+                string title = parameters.TryGetValue("title", out var titleObj) ? titleObj?.ToString() : null;
+                string body = parameters.TryGetValue("body", out var bodyObj) ? bodyObj?.ToString() : null;
+                string state = parameters.TryGetValue("state", out var stateObj) ? stateObj?.ToString() : null;
+                string baseBranch = parameters.TryGetValue("base", out var baseObj) ? baseObj?.ToString() : null;
+                bool? maintainerCanModify = parameters.TryGetValue("maintainer_can_modify", out var maintainerObj) && bool.TryParse(maintainerObj?.ToString(), out bool maintainerValue) ? maintainerValue : (bool?)null;
+
+                string apiKey = _generalSettingsService.GetDecryptedGitHubApiKey();
+                if (string.IsNullOrWhiteSpace(apiKey))
+                {
+                    return CreateResult(false, false, "Error: GitHub Personal Access Token not configured. Please set 'GitHubToken' in the tool's extra properties.");
+                }
+                SendStatusUpdate($"Updating pull request #{pullNumber} in {owner}/{repo}...");
+                var requestBody = new JObject();
+                if (title != null) requestBody["title"] = title;
+                if (body != null) requestBody["body"] = body;
+                if (state != null) requestBody["state"] = state;
+                if (baseBranch != null) requestBody["base"] = baseBranch;
+                if (maintainerCanModify.HasValue) requestBody["maintainer_can_modify"] = maintainerCanModify.Value;
+                string jsonBody = requestBody.ToString();
+                var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
+                _httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", apiKey);
+                string url = $"https://api.github.com/repos/{owner}/{repo}/pulls/{pullNumber}";
+                var response = await _httpClient.PatchAsync(url, content);
+                string responseContent = await response.Content.ReadAsStringAsync();
+                if (response.IsSuccessStatusCode)
+                {
+                    var pullRequest = JsonConvert.DeserializeObject<JObject>(responseContent);
+                    SendStatusUpdate($"Pull request #{pullNumber} updated successfully.");
+                    var result = new
+                    {
+                        success = true,
+                        pullRequest = new
+                        {
+                            number = pullRequest["number"]?.ToString(),
+                            url = pullRequest["html_url"]?.ToString(),
+                            title = pullRequest["title"]?.ToString(),
+                            state = pullRequest["state"]?.ToString(),
+                            @base = pullRequest["base"]?["ref"]?.ToString(),
+                            updated_at = pullRequest["updated_at"]?.ToString()
+                        },
+                        message = $"✅ Pull request #{pullNumber} updated successfully!"
+                    };
+                    return CreateResult(true, false, JsonConvert.SerializeObject(result, Formatting.Indented));
+                }
+                else
+                {
+                    _logger.LogError("GitHub API error: {StatusCode} - {Content}", response.StatusCode, responseContent);
+                    string errorMessage = "Failed to update pull request.";
+                    try
+                    {
+                        var errorResponse = JsonConvert.DeserializeObject<JObject>(responseContent);
+                        if (errorResponse["message"] != null)
+                        {
+                            errorMessage = $"GitHub API Error: {errorResponse["message"]}";
+                            if (errorResponse["errors"] != null)
+                            {
+                                var errors = errorResponse["errors"] as JArray;
+                                if (errors?.Count > 0)
+                                {
+                                    errorMessage += $"\nDetails: {string.Join(", ", errors.Select(e => e["message"]?.ToString()))}";
+                                }
+                            }
+                        }
+                    }
+                    catch
+                    {
+                        errorMessage = $"GitHub API Error: {response.StatusCode} - {responseContent}";
+                    }
+                    return CreateResult(false, false, errorMessage);
+                }
+            }
+            catch (HttpRequestException httpEx)
+            {
+                _logger.LogError(httpEx, "HTTP error in GitHub Update Pull Request tool");
+                return CreateResult(false, false, $"Network error: {httpEx.Message}");
+            }
+            catch (JsonException jsonEx)
+            {
+                _logger.LogError(jsonEx, "JSON parsing error in GitHub Update Pull Request tool");
+                return CreateResult(false, false, $"Error parsing parameters: {jsonEx.Message}");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unexpected error in GitHub Update Pull Request tool");
+                return CreateResult(false, false, $"Unexpected error: {ex.Message}");
+            }
+        }
+    }
+}

--- a/docs/readme/05-key-features-in-detail.md
+++ b/docs/readme/05-key-features-in-detail.md
@@ -102,6 +102,8 @@ AiStudio4 includes a variety of built-in tools. Click on a tool name to learn mo
 *   [GitHubUpdateIssueTool](tools/git-hub-update-issue-tool.md)
 *   [GitHubCreateIssueCommentTool](tools/git-hub-create-issue-comment-tool.md)
 *   [GitHubListIssueCommentsTool](tools/git-hub-list-issue-comments-tool.md)
+*   [GitHubUpdatePullRequestTool](tools/github-update-pull-request-tool.md)
+*   [GitHubListPullRequestsTool](tools/github-list-pull-requests-tool.md)
 
 #### Sentry Tools
 *   [SentryTool](tools/sentry-tool.md)

--- a/docs/readme/tools/github-list-pull-requests-tool.md
+++ b/docs/readme/tools/github-list-pull-requests-tool.md
@@ -1,0 +1,68 @@
+﻿# GitHubListPullRequestsTool
+
+*Lists pull requests for a GitHub repository. Requires GitHub Personal Access Token with repo permissions.*
+
+## Purpose
+This tool enables you to retrieve a list of pull requests from a specified GitHub repository, with optional filtering by state, branch, or pagination. Useful for workflow automation, dashboards, or reviewing PR status directly from AiStudio4.
+
+## Parameters
+- `owner` (string, required): Repository owner (username or organization)
+- `repo` (string, required): Repository name
+- `state` (string, optional): State of the PR: `open`, `closed`, or `all` (default: `open`)
+- `head` (string, optional): Filter by head user or branch name (e.g., `feature-branch`)
+- `base` (string, optional): Filter by base branch name (e.g., `main`)
+- `per_page` (integer, optional): Number of results per page (max 100)
+- `page` (integer, optional): Page number of the results to fetch
+
+## Example Usage
+List all open pull requests targeting the `main` branch in the `octocat/Hello-World` repository:
+
+```
+{
+  "owner": "octocat",
+  "repo": "Hello-World",
+  "base": "main",
+  "state": "open"
+}
+```
+
+## Output
+On success, returns a JSON object containing a list of pull requests:
+
+```
+{
+  "success": true,
+  "count": 2,
+  "pullRequests": [
+    {
+      "number": 42,
+      "title": "Add new feature",
+      "state": "open",
+      "head": "feature-branch",
+      "base_branch": "main",
+      "url": "https://github.com/octocat/Hello-World/pull/42",
+      "user": "octocat",
+      "created_at": "2024-06-01T12:00:00Z",
+      "updated_at": "2024-06-04T17:00:00Z"
+    },
+    {
+      "number": 43,
+      "title": "Fix bug",
+      "state": "open",
+      "head": "bugfix-branch",
+      "base_branch": "main",
+      "url": "https://github.com/octocat/Hello-World/pull/43",
+      "user": "octocat",
+      "created_at": "2024-06-02T13:00:00Z",
+      "updated_at": "2024-06-04T17:10:00Z"
+    }
+  ]
+}
+```
+
+On failure, returns an error message with details from the GitHub API.
+
+## Notes
+- Requires a valid GitHub Personal Access Token with repo permissions configured in AiStudio4.
+- Pagination is supported via `per_page` and `page` parameters.
+- You must have read access to the repository.

--- a/docs/readme/tools/github-update-pull-request-tool.md
+++ b/docs/readme/tools/github-update-pull-request-tool.md
@@ -1,0 +1,54 @@
+﻿# GitHubUpdatePullRequestTool
+
+*Updates an existing pull request in a GitHub repository. Requires GitHub Personal Access Token with repo permissions.*
+
+## Purpose
+This tool allows you to update the properties of an existing pull request on GitHub, such as its title, body, state (open/closed), base branch, and whether maintainers can modify it. This is useful for workflow automation, correcting mistakes, or managing PRs directly from AiStudio4.
+
+## Parameters
+- `owner` (string, required): Repository owner (username or organization)
+- `repo` (string, required): Repository name
+- `pull_number` (integer, required): The number of the pull request to update
+- `title` (string, optional): The new title for the pull request
+- `body` (string, optional): The new contents of the pull request (Markdown)
+- `state` (string, optional): State of the PR: `open` or `closed`
+- `base` (string, optional): The branch you want the changes pulled into
+- `maintainer_can_modify` (boolean, optional): Whether maintainers can modify the PR
+
+## Example Usage
+Update the title and body of pull request #42 in the `octocat/Hello-World` repository:
+
+```
+{
+  "owner": "octocat",
+  "repo": "Hello-World",
+  "pull_number": 42,
+  "title": "New PR Title",
+  "body": "Updated PR description."
+}
+```
+
+## Output
+On success, returns a JSON object with details about the updated pull request:
+
+```
+{
+  "success": true,
+  "pullRequest": {
+    "number": 42,
+    "url": "https://github.com/octocat/Hello-World/pull/42",
+    "title": "New PR Title",
+    "state": "open",
+    "base": "main",
+    "updated_at": "2024-06-04T17:00:00Z"
+  },
+  "message": "✅ Pull request #42 updated successfully!"
+}
+```
+
+On failure, returns an error message with details from the GitHub API.
+
+## Notes
+- Requires a valid GitHub Personal Access Token with repo permissions configured in AiStudio4.
+- Only the fields you provide will be updated; others remain unchanged.
+- You must have write access to the repository and the pull request.


### PR DESCRIPTION
This PR adds detailed documentation for two new GitHub tools:

- **GitHubUpdatePullRequestTool**: Provides full usage details, parameters, example, output, and notes for updating pull requests via the tool system.
- **GitHubListPullRequestsTool**: Provides full usage details, parameters, example, output, and notes for listing pull requests via the tool system.

Both tools are now listed in the GitHub Tools section of the main tool reference (05-key-features-in-detail.md), and each has a dedicated documentation file in docs/readme/tools/.

No changes were made to the main readme.md or introduction, as they do not enumerate individual tools.

---
Closes #19