### PR TITLE
Fix Cancel button text legibility in UserPromptEditor

### DIFF
--- a/AiStudio4/AiStudioClient/src/components/UserPrompt/UserPromptEditor.tsx
+++ b/AiStudio4/AiStudioClient/src/components/UserPrompt/UserPromptEditor.tsx
@@ -1,4 +1,4 @@
-
+﻿
 import React, { useState, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { Form, FormField, FormItem, FormLabel, FormControl, FormDescription, FormMessage } from '@/components/ui/form';
@@ -334,9 +334,12 @@ export function UserPromptEditor({ initialPrompt, onClose, onApply }: UserPrompt
               <Button
                 type="button"
                 onClick={onClose}
-                variant="outline"
                 disabled={isProcessing}
-                className="btn-secondary"
+                style={{
+                  backgroundColor: 'var(--global-background-color)',
+                  color: 'var(--global-text-color)'
+                }}
+                className="border-blue-500"
               >
                 Cancel
               </Button>


### PR DESCRIPTION
## Fixes #23: Grey 'Cancel' text is not legible on white button background in User Prompt Editor

### Problem
The Cancel button in the UserPromptEditor had the same legibility issue as reported in #17 - grey text on white background making it barely readable.

### Root Cause
Conflicting styles between `variant="outline"` and `className="btn-secondary"` causing poor text contrast.

### Solution
Applied the same fix pattern as issue #17:
- Removed conflicting `variant="outline"` and `className="btn-secondary"`
- Applied proper global theme variables:
  - `backgroundColor: 'var(--global-background-color)'`
  - `color: 'var(--global-text-color)'`
- Added `border-blue-500` class for consistent styling with other buttons

### Testing
1. Open User Prompt Library
2. Create new or edit existing user prompt
3. Verify Cancel button text is clearly legible
4. Confirm blue border matches other interface buttons

### Files Changed
- `src/components/UserPrompt/UserPromptEditor.tsx`

This follows the established ComponentTheming.md guidelines and ensures consistent theming across the application.