### PR TITLE
Fix #15: Make database schema configurable via extraProperties with default SHEFFIELD

### DIFF
--- a/AiStudio4/Core/Tools/ReadDatabaseSchemaTool.cs
+++ b/AiStudio4/Core/Tools/ReadDatabaseSchemaTool.cs
@@ -72,8 +72,11 @@ namespace AiStudio4.Core.Tools
                 
                 SendStatusUpdate($"Reading database schema for type: {detailType}{(filter != null ? $", filter: {filter}" : "")}");
 
+                // Get database schema from extraProperties or default to SHEFFIELD
+                string databaseSchema = extraProperties != null && extraProperties.TryGetValue("DatabaseSchema", out var schemaName) && !string.IsNullOrWhiteSpace(schemaName) ? schemaName : "SHEFFIELD";
+
                 // Connection string for SQL Server using Windows Authentication
-                string connectionString = @"Data Source=localhost;Initial Catalog=SHEFFIELD;Integrated Security=True;TrustServerCertificate=True";
+                string connectionString = $@"Data Source=localhost;Initial Catalog={databaseSchema};Integrated Security=True;TrustServerCertificate=True";
 
                 using (var connection = new SqlConnection(connectionString))
                 {

--- a/AiStudio4/Core/Tools/ReadDatabaseSchemaTool.cs
+++ b/AiStudio4/Core/Tools/ReadDatabaseSchemaTool.cs
@@ -51,7 +51,10 @@ namespace AiStudio4.Core.Tools
                 Categories = new List<string> { "Development" },
                 OutputFileType = "txt",
                 Filetype = string.Empty,
-                LastModified = DateTime.UtcNow
+                LastModified = DateTime.UtcNow,
+                ExtraProperties = new Dictionary<string, string> {
+                    { "DatabaseSchema", "SHEFFIELD" }
+                }
             };
         }
 


### PR DESCRIPTION
This PR fixes issue #15 by making the database schema configurable via the tool's extraProperties dictionary with a default value of "SHEFFIELD". The AI cannot override this parameter, ensuring security. The ReadDatabaseSchemaTool reads the schema from extraProperties and constructs the connection string accordingly. The tool definition now includes the default extraProperty for DatabaseSchema.

Testing instructions:
- Configure the ReadDatabaseSchema tool in the UI to set the "DatabaseSchema" extraProperty to a test database.
- Run the tool to verify it connects to the specified database.
- Run the tool without setting the extraProperty to verify it defaults to "SHEFFIELD".
- Verify the AI cannot override the schema by passing toolParameters.