### PR TITLE
Add Repack Project Source Code functionality

### DIFF
--- a/AiStudio4/InjectedDependencies/GeneralSettings.cs
+++ b/AiStudio4/InjectedDependencies/GeneralSettings.cs
@@ -38,6 +38,7 @@ namespace AiStudio4.InjectedDependencies
         public List<string> PackerIncludeFileTypes { get; set; } = new List<string>();
         public List<string> PackerExcludeFilenames { get; set; } = new List<string>();
         public List<string> PackerExcludeFolderNames { get; set; } = new List<string>();
+        public string LastPackerOutputFile { get; set; }
 
         // Wiki System Prompt Sync Settings
         public bool EnableWikiSystemPromptSync { get; set; } = false;

--- a/AiStudio4/MainWindow.xaml
+++ b/AiStudio4/MainWindow.xaml
@@ -45,6 +45,7 @@
                 <MenuItem Header="_Set Project Path..." Click="SetProjectPathMenuItem_Click"/>
                 <Separator/>
                 <MenuItem Header="_Pack Project Source Code" Click="PackProjectSourceCode_Click"/>
+                <MenuItem Header="_Repack Project Source Code" Click="RepackProjectSourceCode_Click"/>
                 <MenuItem Header="_Set Packer Include File Types..." Click="SetPackerIncludeTypesMenuItem_Click"/>
                 <MenuItem Header="_Set Packer Exclude Filenames..." Click="SetPackerExcludeFilenamesMenuItem_Click"/>
                 <MenuItem Header="_Set Packer Exclude Folder Names..." Click="SetPackerExcludeFolderNamesMenuItem_Click"/>

--- a/docs/readme/04-using-aistudio4.md
+++ b/docs/readme/04-using-aistudio4.md
@@ -170,10 +170,46 @@ AiStudio4 can automatically synchronize system prompts with Azure DevOps wiki pa
 *   **Automatic Updates:** Ensure AI prompts stay current with project requirements and guidelines
 *   **Version Control:** Leverage Azure DevOps wiki's version control for prompt management
 
-## 4.8 Google AI Studio Integration
+## 4.8 Project Source Code Packaging
+AiStudio4 provides tools to package your project's source code into a comprehensive XML format for AI analysis and sharing.
+
+### 4.8.1 Pack Project Source Code
+1. **Access the Feature:**
+   * Go to `Project > Pack Project Source Code` in the application menu.
+2. **Configure Packaging Options (Optional):**
+   * Set file types to include: `Project > Set Packer Include File Types...`
+   * Set specific filenames to exclude: `Project > Set Packer Exclude Filenames...`
+   * Set folder names to exclude: `Project > Set Packer Exclude Folder Names...`
+3. **Create Package:**
+   * A file dialog will appear asking where to save the XML package.
+   * Choose your desired location and filename (defaults to `ProjectName_SourceCode.xml`).
+   * The tool will create a comprehensive XML package containing your project's source code.
+   * The packaging process respects `.gitignore` rules and your configured include/exclude settings.
+   * The output file path is automatically saved for future repack operations.
+
+### 4.8.2 Repack Project Source Code
+1. **Quick Repack:**
+   * Go to `Project > Repack Project Source Code` in the application menu.
+   * This will automatically re-run the packaging process using the same output file path as your last pack operation.
+   * No file dialog is shown - the project is packed directly to the previously used location.
+2. **Use Cases:**
+   * Iterative development workflows where you frequently update the packaged project snapshot.
+   * Quick updates after making changes to your codebase.
+   * Automated packaging in development scripts or workflows.
+3. **Requirements:**
+   * You must have used "Pack Project Source Code" at least once to establish an output file location.
+   * If no previous pack location exists, you'll be prompted to use "Pack Project Source Code" first.
+
+### 4.8.3 Package Contents and Uses
+* **XML Structure:** The output includes the complete directory structure and content of each included file.
+* **AI Integration:** Useful for providing large codebase snapshots to AI models that have context window limitations or no direct file system access.
+* **Code Review:** Can be shared with team members or external reviewers for comprehensive code analysis.
+* **Documentation:** Serves as a snapshot of your project at a specific point in time.
+
+## 4.9 Google AI Studio Integration
 AiStudio4 allows you to import conversations from Google AI Studio and export conversations back to Google Drive for use in Google's ecosystem.
 
-### 4.8.1 Importing Conversations from Google AI Studio
+### 4.9.1 Importing Conversations from Google AI Studio
 1.  **Ensure Setup:** 
     *   A `credentials.json` file (obtained from your Google Cloud Console for an OAuth 2.0 Desktop app) is required in your `%APPDATA%\AiStudio4\Config\` directory.
     *   You may need to authorize AiStudio4 to access your Google Drive the first time you use this feature.
@@ -190,7 +226,7 @@ AiStudio4 allows you to import conversations from Google AI Studio and export co
     *   The selected messages will be converted and saved as a new conversation in AiStudio4.
     *   The new conversation(s) will appear in your Conversation History, and the first successfully imported conversation will be automatically loaded.
 
-### 4.8.2 Exporting Conversations to Google AI Studio
+### 4.9.2 Exporting Conversations to Google AI Studio
 1.  **Ensure Setup:** Similar to importing, ensure Google Drive authorization is complete and the "Google AI Studio" folder exists.
 2.  **Initiate Export:**
     *   Go to `File > Import/Export > Upload current thread to Google AI Studio....`

--- a/docs/readme/05-key-features-in-detail.md
+++ b/docs/readme/05-key-features-in-detail.md
@@ -214,11 +214,17 @@ In the Input Bar:
 *   This file can then be used as context for AI tasks, for example, by attaching it to a prompt or having the AI read it using the `ReadFiles` tool.
 
 ### 5.4.2 Project Source Code Packaging
-*   From the application menu: `Project > Pack Project Source Code`.
-*   This tool creates a comprehensive XML package containing the source code of your project.
-*   It respects `.gitignore` rules.
-*   You can configure which file types to include (`Project > Set Packer Include File Types...`), specific filenames/patterns to exclude (`Project > Set Packer Exclude Filenames...`), and specific folder names to exclude (`Project > Set Packer Exclude Folder Names...`).
-*   The output XML includes the directory structure and the content of each included file. This is useful for providing a large codebase snapshot to an AI that might have context window limitations or no direct file system access.
+*   **Pack Project Source Code:** From the application menu: `Project > Pack Project Source Code`.
+    *   This tool creates a comprehensive XML package containing the source code of your project.
+    *   It respects `.gitignore` rules.
+    *   You can configure which file types to include (`Project > Set Packer Include File Types...`), specific filenames/patterns to exclude (`Project > Set Packer Exclude Filenames...`), and specific folder names to exclude (`Project > Set Packer Exclude Folder Names...`).
+    *   The output XML includes the directory structure and the content of each included file. This is useful for providing a large codebase snapshot to an AI that might have context window limitations or no direct file system access.
+    *   When you first pack a project, the output file path is saved for future use.
+*   **Repack Project Source Code:** From the application menu: `Project > Repack Project Source Code`.
+    *   This feature allows you to quickly re-run the packaging process using the same output file path as your last pack operation.
+    *   No file dialog is shown - the project is automatically packed to the previously used location.
+    *   This is useful for iterative development workflows where you frequently need to update the packaged project snapshot.
+    *   If you haven't used "Pack Project Source Code" first, you'll be prompted to do so to establish an initial output file location.
 
 ## 5.5 Backend and Core Functionality
 

--- a/docs/readme/CHANGELOG.md
+++ b/docs/readme/CHANGELOG.md
@@ -1,5 +1,25 @@
 ﻿# Changelog
 
+All notable changes to AiStudio4 will be documented in this file.
+
+## [Unreleased]
+
+### Added
+- **Repack Project Source Code**: New menu item `Project > Repack Project Source Code` that allows quick re-packaging of project source code using the previously saved output file path
+- **DRY Refactored Packaging Logic**: Extracted common packaging logic into a reusable `ExecutePackingOperationAsync` helper method for better maintainability
+- **Last Packer Output File Persistence**: The application now remembers the last used output file path for packing operations, stored in `GeneralSettings.LastPackerOutputFile`
+
+### Changed
+- **Improved Pack Project Source Code**: Refactored the existing pack functionality to use the new DRY architecture and automatically save the output path for future repack operations
+- **Enhanced User Experience**: Streamlined workflow for iterative development where users frequently need to update packaged project snapshots
+
+### Technical Details
+- Added `LastPackerOutputFile` property to `GeneralSettings.cs`
+- Created `ExecutePackingOperationAsync` helper method in `MainWindow.xaml.cs`
+- Refactored `PackProjectSourceCode_Click` to use the new helper method and save output path
+- Added new `RepackProjectSourceCode_Click` event handler for the repack functionality
+- Updated documentation in user guide sections 4.8 and 5.4.2 to cover the new repack feature
+
 ## Changes Since Version 0.93
 
 ### New Features


### PR DESCRIPTION
## Summary
This PR implements the "Repack Project Source Code" feature requested in issue #54.

## Changes Made
- **Added new menu item**: `Project > Repack Project Source Code` for quick re-packaging using the previously saved output file path
- **DRY Refactoring**: Extracted common packaging logic into a reusable `ExecutePackingOperationAsync` helper method
- **Persistent Output Path**: Added `LastPackerOutputFile` setting to `GeneralSettings` to remember the last used output file path
- **Enhanced User Experience**: Streamlined workflow for iterative development where users frequently need to update packaged project snapshots
- **Updated Documentation**: Added comprehensive documentation for both pack and repack features in user guide sections 4.8 and 5.4.2

## Technical Implementation
- Added `LastPackerOutputFile` property to `GeneralSettings.cs`
- Created `ExecutePackingOperationAsync` helper method in `MainWindow.xaml.cs`
- Refactored `PackProjectSourceCode_Click` to use the new helper method and automatically save output path
- Added new `RepackProjectSourceCode_Click` event handler for the repack functionality
- Updated CHANGELOG.md with detailed feature description

## Benefits
- **Faster Workflow**: No need to navigate file dialogs for repeat packaging operations
- **Consistency**: Always uses the same output location for predictable results
- **Maintainability**: DRY code architecture makes future enhancements easier
- **User-Friendly**: Clear error messages guide users through proper usage

Fixes #54