### PR TITLE
Remove Recent Projects menu functionality

### DIFF
--- a/AiStudio4/MainWindow.xaml
+++ b/AiStudio4/MainWindow.xaml
@@ -51,8 +51,6 @@
                 <MenuItem Header="_Set Packer Exclude Folder Names..." Click="SetPackerExcludeFolderNamesMenuItem_Click"/>
                 <Separator/>
                 <MenuItem Header="_Analyze .NET Projects" Click="AnalyzeDotNetProjects_Click"/>
-                <Separator/>
-                <MenuItem Header="_Recent Projects" Name="RecentProjectsMenuItem"/>
             </MenuItem>
             <MenuItem Header="📂" ToolTip="Opens the project root folder in an Explorer window" Click="ExploreProjectMenuItem_Click"/>
             <MenuItem Header="_Transcribe">

--- a/AiStudio4/MainWindow.xaml.cs
+++ b/AiStudio4/MainWindow.xaml.cs
@@ -98,7 +98,6 @@ public partial class WebViewWindow : Window
         
         InitializeComponent();
         UpdateWindowTitle(); 
-        UpdateRecentProjectsMenu(); 
         UpdateAllowConnectionsOutsideLocalhostMenuItem(); 
         UpdateUseExperimentalCostTrackingMenuItem();
         UpdateUpdateAvailableMenuItem();
@@ -461,7 +460,6 @@ public partial class WebViewWindow : Window
                     _builtinToolService.UpdateProjectRoot();
                     
                     UpdateWindowTitle(); 
-                    UpdateRecentProjectsMenu(); 
                 }
             }
             catch (Exception ex)
@@ -471,68 +469,11 @@ public partial class WebViewWindow : Window
         }
     }
 
-    private void UpdateRecentProjectsMenu()
-    {
-        RecentProjectsMenuItem.Items.Clear();
-        var history = _projectHistoryService.GetProjectPathHistory();
 
-        if (history == null || !history.Any())
-        {
-            RecentProjectsMenuItem.IsEnabled = false;
-            return;
-        }
 
-        RecentProjectsMenuItem.IsEnabled = true;
-        for (int i = 0; i < history.Count; i++)
-        {
-            var path = history[i];
-            var menuItem = new MenuItem
-            {
-                Header = FormatPathForMenu(path, i + 1),
-                Tag = path 
-            };
-            menuItem.Click += RecentProjectPathMenuItem_Click;
-            RecentProjectsMenuItem.Items.Add(menuItem);
-        }
-    }
 
-    private string FormatPathForMenu(string path, int index)
-    {
-        
-        const int maxLength = 50;
-        string displayPath = path.Length > maxLength ? "..." + path.Substring(path.Length - maxLength) : path;
-        return $"_{index} {displayPath}"; 
-    }
 
-    private void RecentProjectPathMenuItem_Click(object sender, RoutedEventArgs e)
-    {
-        if (sender is MenuItem menuItem && menuItem.Tag is string selectedPath)
-        {
-            try
-            {
-                string oldPath = _generalSettingsService.CurrentSettings.ProjectPath;
-                
-                
-                if (selectedPath != oldPath)
-                {
-                    _generalSettingsService.CurrentSettings.ProjectPath = selectedPath;
-                    _projectHistoryService.AddProjectPathToHistory(selectedPath);
-                    _generalSettingsService.SaveSettings();
-                    _projectHistoryService.SaveSettings();
-                    
-                    
-                    _builtinToolService.UpdateProjectRoot();
-                    
-                    UpdateWindowTitle();
-                    UpdateRecentProjectsMenu();
-                }
-            }
-            catch (Exception ex)
-            {
-                MessageBox.Show($"Error setting project path from history: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
-            }
-        }
-    }
+
     
     private void ExploreProjectMenuItem_Click(object sender, RoutedEventArgs e)
     {


### PR DESCRIPTION
This PR removes the Recent Projects menu functionality as requested in issue #61.

## Changes Made:
- Removed the "Recent Projects" MenuItem from the Project menu in MainWindow.xaml
- Removed all associated code from MainWindow.xaml.cs:
  - `UpdateRecentProjectsMenu()` method and all calls to it
  - `FormatPathForMenu()` helper method
  - `RecentProjectPathMenuItem_Click()` event handler

## Testing:
- Verified that the Project menu no longer contains the Recent Projects submenu
- Confirmed that other Project menu functionality remains intact
- Application builds and runs without errors

Fixes #61