### PR TITLE
AiStudio4: Refactor message selection logic

### DIFF
--- a/AiStudio4/AiStudioClient/src/components/ConvTreeView/ConvTreeView.tsx
+++ b/AiStudio4/AiStudioClient/src/components/ConvTreeView/ConvTreeView.tsx
@@ -5,6 +5,7 @@ import { Message } from '@/types/conv';
 import { useConvStore } from '@/stores/useConvStore';
 import { useThemeStore } from '@/stores/useThemeStore';
 import { useSearchStore } from '@/stores/useSearchStore';
+import { useMessageSelection } from '@/hooks/useMessageSelection';
 import { TreeViewProps } from './types';
 import { useMessageTree } from './useMessageTree';
 import { useTreeVisualization } from './useTreeVisualization';
@@ -16,7 +17,8 @@ import { useWebSocketStore } from '@/stores/useWebSocketStore';
 
 const ConvTreeViewComponent: React.FC<TreeViewProps> = ({ convId, messages }) => {
     const [updateKey, setUpdateKey] = useState(0);
-    const { setActiveConv, convs, slctdMsgId } = useConvStore();
+    const { convs, slctdMsgId } = useConvStore();
+    const { selectMessage } = useMessageSelection();
     const { searchResults, highlightedMessageId, cycleToNextMatch } = useSearchStore();
     const svgRef = useRef<SVGSVGElement>(null);
     const containerRef = useRef<HTMLDivElement>(null);
@@ -63,10 +65,7 @@ const ConvTreeViewComponent: React.FC<TreeViewProps> = ({ convId, messages }) =>
                 
                 // If it has a parent, select the parent (AI message)
                 if (message.parentId) {
-                    setActiveConv({
-                        convId: convId,
-                        slctdMsgId: message.parentId,
-                    });
+                    selectMessage(message.parentId, convId);
                     // Scroll to the last message after a brief delay
                     setTimeout(() => scrollToMessage(), 100);
                     return;
@@ -74,12 +73,10 @@ const ConvTreeViewComponent: React.FC<TreeViewProps> = ({ convId, messages }) =>
             }
         }
         
-        setActiveConv({
-            convId: convId, slctdMsgId: nodeId,
-        });
+        selectMessage(nodeId, convId);
         // Scroll to the last message after a brief delay
         setTimeout(() => scrollToMessage(), 100);
-    }, [convId, convs, setActiveConv]);
+    }, [convId, convs, selectMessage]);
 
     // Handle middle-click to delete a message and its descendants
     const handleNodeMiddleClick = useCallback((event: any, nodeId: string) => {

--- a/AiStudio4/AiStudioClient/src/components/HistoricalConvTreeList.tsx
+++ b/AiStudio4/AiStudioClient/src/components/HistoricalConvTreeList.tsx
@@ -5,6 +5,7 @@ import { useConvStore } from '@/stores/useConvStore';
 import { useHistoricalConvsStore } from '@/stores/useHistoricalConvsStore';
 import { useSearchStore } from '@/stores/useSearchStore';
 import { useChatManagement } from '@/hooks/useChatManagement';
+import { useMessageSelection } from '@/hooks/useMessageSelection';
 import { Search, X, MessageSquare } from 'lucide-react';
 import { ScrollArea } from '@/components/ui/scroll-area';
 
@@ -75,7 +76,8 @@ const HistoricalConvTreeListComponent = ({ searchResults }: HistoricalConvTreeLi
     // Optimize store subscriptions to reduce re-renders during livestream events
     const clientId = useWebSocketStore(state => state.clientId);
     const currentRequest = useWebSocketStore(state => state.currentRequest);
-    const { createConv, addMessage, setActiveConv, convs: currentConvs } = useConvStore();
+    const { createConv, addMessage, convs: currentConvs } = useConvStore();
+    const { selectMessage } = useMessageSelection();
     const { convs, fetchAllConvs, addOrUpdateConv, deleteConv, isLoadingList } = useHistoricalConvsStore();
     const { highlightMessage } = useSearchStore();
 
@@ -158,18 +160,11 @@ const HistoricalConvTreeListComponent = ({ searchResults }: HistoricalConvTreeLi
 
 
                 if (selectedMessage && selectedMessage.source === 'user' && selectedMessage.parentId) {
-
-
-                    setActiveConv({
-                        convId,
-                        slctdMsgId: selectedMessage.parentId,
-                    });
+                    
+                    selectMessage(selectedMessage.parentId, convId);
                 } else {
-
-                    setActiveConv({
-                        convId,
-                        slctdMsgId: nodeId,
-                    });
+                    
+                    selectMessage(nodeId, convId);
                 }
                 return;
             }
@@ -228,23 +223,11 @@ const HistoricalConvTreeListComponent = ({ searchResults }: HistoricalConvTreeLi
 
 
                 if (selectedMessage && selectedMessage.source === 'user' && selectedMessage.parentId) {
-
-                    window.history.pushState({}, '', `?messageId=${selectedMessage.parentId}`);
-
-
-                    setActiveConv({
-                        convId,
-                        slctdMsgId: selectedMessage.parentId,
-                    });
+                    
+                    selectMessage(selectedMessage.parentId, convId);
                 } else {
-
-                    window.history.pushState({}, '', `?messageId=${nodeId}`);
-
-
-                    setActiveConv({
-                        convId,
-                        slctdMsgId: nodeId,
-                    });
+                    
+                    selectMessage(nodeId, convId);
                 }
             } else {
                 
@@ -252,7 +235,7 @@ const HistoricalConvTreeListComponent = ({ searchResults }: HistoricalConvTreeLi
         } catch (error) {
             
         }
-    }, [clientId, searchResults, highlightMessage, currentConvs, setActiveConv, getConv, createConv, addMessage]);
+    }, [clientId, searchResults, highlightMessage, currentConvs, selectMessage, getConv, createConv, addMessage]);
 
     // Filter conversations based on search results if available - memoized for performance
     const displayedConvs = useMemo(() => {

--- a/AiStudio4/AiStudioClient/src/components/InputBar/InputBar.tsx
+++ b/AiStudio4/AiStudioClient/src/components/InputBar/InputBar.tsx
@@ -137,7 +137,6 @@ export function InputBar({
     const handleChatMessage = useCallback(async (message: string, messageAttachments?: Attachment[]) => {
         try {
             let convId = activeConvId;
-            let parentMessageId = null;
             let systemPromptId = null;
             let systemPromptContent = null;
 
@@ -148,9 +147,6 @@ export function InputBar({
                     id: convId,
                     rootMessage: { id: messageId, content: '', source: 'system', timestamp: Date.now() },
                 });
-                parentMessageId = messageId;
-            } else {
-                parentMessageId = slctdMsgId || (convs[convId]?.messages.length > 0 ? convs[convId].messages[convs[convId].messages.length - 1].id : null);
             }
 
             if (convId) {
@@ -162,10 +158,9 @@ export function InputBar({
             const messageId = `msg_${uuidv4()}`;
             setCurrentRequest({ convId, messageId });
 
-            // --- MODIFIED: `model` property is no longer passed here ---
+            // parentMessageId is now handled internally by sendMessage via store state
             await sendMessage({
                 convId,
-                parentMessageId,
                 message,
                 systemPromptId,
                 systemPromptContent,

--- a/AiStudio4/AiStudioClient/src/hooks/useChatManagement.ts
+++ b/AiStudio4/AiStudioClient/src/hooks/useChatManagement.ts
@@ -41,7 +41,6 @@ const useChatConfigResource = createResourceHook<{
 
 interface SendMessageParams {
     convId: string;
-    parentMessageId: string;
     message: string;
     systemPromptId?: string;
     systemPromptContent?: string;
@@ -58,12 +57,15 @@ export function useChatManagement() {
     const sendMessage = useCallback(
         async (params: Omit<SendMessageParams, 'model'>) => {
             return executeApiCall(async () => {
-                const newMessageId = params.messageId || (params.parentMessageId ? uuidv4() : undefined);
+                const { slctdMsgId } = useConvStore.getState(); // Get it from the store
+                const parentMessageId = slctdMsgId; // Use the current selected message ID
+                
+                const newMessageId = params.messageId || (parentMessageId ? uuidv4() : undefined);
                 
                 // Get current active tools from store to ensure they're fresh
                 const { activeTools } = useToolStore.getState();
                 
-                let requestParams: Partial<SendMessageParams> = { ...params, toolIds: activeTools };
+                let requestParams: any = { ...params, parentMessageId, toolIds: activeTools };
 
 
                 if (params.attachments && params.attachments.length > 0) {

--- a/AiStudio4/AiStudioClient/src/hooks/useMessageSelection.ts
+++ b/AiStudio4/AiStudioClient/src/hooks/useMessageSelection.ts
@@ -1,0 +1,42 @@
+﻿// src/hooks/useMessageSelection.ts
+import { useCallback } from 'react';
+import { useConvStore } from '@/stores/useConvStore';
+
+export function useMessageSelection() {
+  // Use separate store calls to avoid object creation causing infinite re-renders
+  const convs = useConvStore(state => state.convs);
+  const activeConvId = useConvStore(state => state.activeConvId);
+
+  /**
+   * Selects a message in a conversation, making it the current head of the branch.
+   * @param messageId The ID of the message to select.
+   * @param convId The ID of the conversation. Defaults to the active conversation.
+   */
+  const selectMessage = useCallback((messageId: string, convId?: string) => {
+    const targetConvId = convId || activeConvId;
+    if (!targetConvId) return;
+
+    // Get the selectMessage function directly from store to avoid subscription issues
+    useConvStore.getState().selectMessage(targetConvId, messageId);
+
+    // Update URL for deep linking
+    window.history.pushState({}, '', `?messageId=${messageId}`);
+  }, [activeConvId]);
+
+  /**
+   * Selects the most recent message in the active conversation.
+   */
+  const selectLatestMessage = useCallback(() => {
+    if (!activeConvId) return;
+    const conv = convs[activeConvId];
+    if (!conv || conv.messages.length === 0) return;
+
+    const latestMessage = conv.messages.reduce((latest, current) => 
+      current.timestamp > latest.timestamp ? current : latest
+    );
+
+    selectMessage(latestMessage.id, activeConvId);
+  }, [activeConvId, convs, selectMessage]);
+
+  return { selectMessage, selectLatestMessage };
+}


### PR DESCRIPTION
- ConvTreeView: Replace setActiveConv with selectMessage hook for message selection
- HistoricalConvTreeList: Replace setActiveConv with selectMessage hook, clean up selection logic
- InputBar: Remove parentMessageId handling, delegate to store
- useChatManagement: Remove parentMessageId param, get selected message from store
- useConvStore: Add selectMessage method, simplify setActiveConv, auto-select latest message on conv switch
- Add new hook useMessageSelection for message selection abstraction